### PR TITLE
fix: licencefile glob on windows

### DIFF
--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -187,7 +187,7 @@ class LicensePlugin {
 
           // Read license file, if it exists.
           const cwd = this._cwd || process.cwd();
-          const absolutePath = path.join(dir, 'LICENSE*');
+          const absolutePath = path.join(dir, '[lL][iI][cC][eE][nN][cCsS][eE]*');
           const relativeToCwd = path.relative(cwd, absolutePath);
           const licenseFile = this._findGlob(relativeToCwd, cwd)[0];
           if (licenseFile) {
@@ -343,7 +343,6 @@ class LicensePlugin {
   _findGlob(pattern, cwd) {
     return glob.sync(pattern, {
       cwd,
-      nocase: true,
     });
   }
 


### PR DESCRIPTION
I'm the maintainer of webpack-license-plugin, so I have quite extensive experience with license compliance and reaching it with JavaScript build tools.

I was having the problem that your plugin didn't find any licenseTexts, even though the /LICEN[CS]E/i files were in the appropriate node_modules subdirectories. Turns out this is a problem that the glob library has had on windows (turns out, even on WSL for windows, which I'm using) for years when you use it with the nocase option.

To fix this, I removed the nocase option and instead adjusted the glob pattern from LICENSE* to [lL][iI][cC][eE][nN][sS][eE]*. It's not nice, but it circumvents any problems finding these files on windows.

Because of my experience with the webpack plugin linked above, I also know that a few projects name their files LICENCE instead of LICENSE, so i included this option in the new glob pattern, making it [lL][iI][cC][eE][nN][cCsS][eE]*.